### PR TITLE
Fix constant redefinition warning for marker library

### DIFF
--- a/libraries/marker.rb
+++ b/libraries/marker.rb
@@ -1,6 +1,6 @@
 class Chef::Recipe
 
-  MARKER_DIR = "#{ENV['HOME']}/.install_markers"
+  MARKER_DIR = "#{ENV['HOME']}/.install_markers" unless const_defined?(:MARKER_DIR)
 
   #Regarding marker files:
   #


### PR DESCRIPTION
This adds a guard to only define `MARKER_DIR` if not already defined.  For cookbooks that depend on this one that have ChefSpec tests, you will no longer see repeated errors like the following:

    $ bundle exec rspec
    ./var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: already initialized constant Chef::Recipe::MARKER_DIR
    /var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: previous definition of MARKER_DIR was here
    ./var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: already initialized constant Chef::Recipe::MARKER_DIR
    /var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: previous definition of MARKER_DIR was here
    ./var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: already initialized constant Chef::Recipe::MARKER_DIR
    /var/folders/f0/49hvn6tn71723n4840d566vm0000gn/T/d20151118-34258-10nez4w/cookbooks/sprout-base/libraries/marker.rb:3: warning: previous definition of MARKER_DIR was here
    [...SNIP...]