### PR TITLE
Log sprout home using Chef::Log.info facility for quieter ChefSpec & soloist runs

### DIFF
--- a/attributes/bash_it.rb
+++ b/attributes/bash_it.rb
@@ -1,6 +1,6 @@
 include_attribute 'sprout-base::home'
 
-p node['sprout']['home']
+Chef::Log.info(node['sprout']['home'])
 
 node.default['bash_it'] ={
   'enabled_plugins' => {


### PR DESCRIPTION
This makes any ChefSpec test runs that depend on this cookbook quieter so they don't output lines like:

    $ bundle exec rspec
    ./Users/foobar
    ./Users/foobar
    ./Users/foobar
    [...SNIP...]

If this output is still interesting or useful, it can still be accessed with `--log_level info` or above:

    chef-solo -l info
    LOG_LEVEL=info soloist
    LOG_LEVEL=debug soloist

If this output is still interesting in ChefSpec, it can be turned on with:

    ChefSpec::SoloRunner.new(log_level: :info).converge(described_recipe)