### PR TITLE
git pair support added to bash-it

### DIFF
--- a/attributes/bash_it.rb
+++ b/attributes/bash_it.rb
@@ -13,7 +13,6 @@ node.default['bash_it'] ={
         bash_it/custom/disable_ctrl-s_output_control.bash
         bash_it/custom/enable_ctrl-o_history_execution.bash
         bash_it/custom/ensure_usr_local_dirs_first.bash
-        bash_it/custom/add_user_initials_to_git_prompt_info.bash
       ]
   },
   'theme' => 'bobby',

--- a/templates/default/bash_it/bashrc.erb
+++ b/templates/default/bash_it/bashrc.erb
@@ -6,5 +6,12 @@ export BASH_IT="<%= node["bash_it"]["dir"] %>"
 # Lock and Load a custom theme file
 export BASH_IT_THEME="<%= node["bash_it"]["theme"] %>"
 
+# enable user/pair initials in git prompt
+export SCM_GIT_SHOW_CURRENT_USER=true
+
+# optionally change prefix and suffix, defaults are below.
+# export SCM_THEME_CURRENT_USER_PREFFIX=' ☺︎ '
+# export SCM_THEME_CURRENT_USER_SUFFIX=' '
+
 # Load Bash It
 source $BASH_IT/bash_it.sh

--- a/templates/default/bash_it/custom/add_user_initials_to_git_prompt_info.bash
+++ b/templates/default/bash_it/custom/add_user_initials_to_git_prompt_info.bash
@@ -1,6 +1,0 @@
-function git_prompt_info {
-  git_prompt_vars
-  GIT_DUET_INITIALS=$(echo $(git config --get-regexp ^duet.env.git-.*-name | sed -e 's/^.*-name //' | tr 'A-Z' 'a-z' | sed -e 's/\([a-z]\)[^ +]*./\1/g' ) | sed -e 's/ /+/')
-  GIT_PAIR=${GIT_DUET_INITIALS:-`git config user.initials | sed 's% %+%'`}
-  echo -e " $GIT_PAIR$SCM_PREFIX$SCM_BRANCH$SCM_STATE$SCM_SUFFIX"
-}


### PR DESCRIPTION
It's no longer necessary to provide a custom prompt replacement, since `bash-it` now includes it.
- this PR: https://github.com/Bash-it/bash-it/pull/680
- docs: https://github.com/Bash-it/bash-it#git-user

Thanks!
